### PR TITLE
Implement basic admin dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@
 # https://app.supabase.com/project/_/settings/api
 NEXT_PUBLIC_SUPABASE_URL=your-project-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+
+# Comma separated list of admin emails
+ADMIN_EMAILS=admin@example.com

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ If you wish to just develop locally and not deploy to Vercel, [follow the steps 
    ```
    NEXT_PUBLIC_SUPABASE_URL=[INSERT SUPABASE PROJECT URL]
    NEXT_PUBLIC_SUPABASE_ANON_KEY=[INSERT SUPABASE PROJECT API ANON KEY]
+   # Comma separated list of admin user emails
+   ADMIN_EMAILS=admin@example.com
    ```
 
    Both `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` can be found in [your Supabase project's API settings](https://supabase.com/dashboard/project/_?showConnect=true)

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,68 @@
+import { DeployButton } from "@/components/deploy-button";
+import { EnvVarWarning } from "@/components/env-var-warning";
+import { AuthButton } from "@/components/auth-button";
+import { ThemeSwitcher } from "@/components/theme-switcher";
+import { hasEnvVars } from "@/lib/utils";
+import { createClient } from "@/lib/supabase/server";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    redirect("/auth/login");
+  }
+
+  const admins = (process.env.ADMIN_EMAILS || "").split(",").map((s) => s.trim()).filter(Boolean);
+  if (!admins.includes(user.email ?? "")) {
+    redirect("/");
+  }
+
+  return (
+    <main className="min-h-screen flex flex-col items-center">
+      <div className="flex-1 w-full flex flex-col gap-20 items-center">
+        <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
+          <div className="w-full max-w-5xl flex justify-between items-center p-3 px-5 text-sm">
+            <div className="flex gap-5 items-center font-semibold">
+              <Link href="/">Next.js Supabase Starter</Link>
+              <Link href="/admin/products" className="hover:underline">
+                Products
+              </Link>
+              <Link href="/admin/orders" className="hover:underline">
+                Orders
+              </Link>
+              <div className="flex items-center gap-2">
+                <DeployButton />
+              </div>
+            </div>
+            {!hasEnvVars ? <EnvVarWarning /> : <AuthButton />}
+          </div>
+        </nav>
+        <div className="flex-1 flex flex-col gap-20 max-w-5xl p-5">{children}</div>
+        <footer className="w-full flex items-center justify-center border-t mx-auto text-center text-xs gap-8 py-16">
+          <p>
+            Powered by{" "}
+            <a
+              href="https://supabase.com/?utm_source=create-next-app&utm_medium=template&utm_term=nextjs"
+              target="_blank"
+              className="font-bold hover:underline"
+              rel="noreferrer"
+            >
+              Supabase
+            </a>
+          </p>
+          <ThemeSwitcher />
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -1,0 +1,26 @@
+import { createClient } from "@/lib/supabase/server";
+
+export default async function OrdersPage() {
+  const supabase = await createClient();
+  const { data: orders, error } = await supabase
+    .from("orders")
+    .select("*")
+    .order("id", { ascending: false });
+  if (error) {
+    console.error(error);
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <h1 className="text-2xl font-bold">Orders</h1>
+      <ul className="flex flex-col gap-4">
+        {orders?.map((order) => (
+          <li key={order.id} className="border p-4 rounded">
+            <p className="font-semibold">Order #{order.id}</p>
+            <pre className="text-xs mt-2">{JSON.stringify(order, null, 2)}</pre>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -1,0 +1,31 @@
+import { createClient } from "@/lib/supabase/server";
+import { ProductForm } from "@/components/admin/product-form";
+
+export default async function ProductsPage() {
+  const supabase = await createClient();
+  const { data: products, error } = await supabase.from("products").select("*").order("id");
+  if (error) {
+    console.error(error);
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <h1 className="text-2xl font-bold">Products</h1>
+      <ProductForm />
+      <ul className="flex flex-col gap-4">
+        {products?.map((product) => (
+          <li key={product.id} className="border p-4 rounded">
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="font-semibold">{product.name}</p>
+                <p className="text-sm text-muted-foreground">{product.description}</p>
+                <p className="text-sm">${product.price}</p>
+              </div>
+              <ProductForm product={product} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/admin/product-form.tsx
+++ b/components/admin/product-form.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useRouter } from "next/navigation";
+
+export function ProductForm({
+  product,
+}: {
+  product?: { id: number; name: string; description: string; price: number };
+}) {
+  const [name, setName] = useState(product?.name ?? "");
+  const [description, setDescription] = useState(product?.description ?? "");
+  const [price, setPrice] = useState(product?.price?.toString() ?? "");
+  const router = useRouter();
+  const supabase = createClient();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (product) {
+      await supabase
+        .from("products")
+        .update({ name, description, price: Number(price) })
+        .eq("id", product.id);
+    } else {
+      await supabase.from("products").insert({ name, description, price: Number(price) });
+      setName("");
+      setDescription("");
+      setPrice("");
+    }
+    router.refresh();
+  };
+
+  const handleDelete = async () => {
+    if (!product) return;
+    await supabase.from("products").delete().eq("id", product.id);
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 w-full max-w-md">
+      <Input
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        required
+      />
+      <Textarea
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <Input
+        type="number"
+        placeholder="Price"
+        value={price}
+        onChange={(e) => setPrice(e.target.value)}
+        required
+      />
+      <div className="flex gap-2">
+        <Button type="submit" size="sm">
+          {product ? "Update" : "Create"}
+        </Button>
+        {product && (
+          <Button type="button" variant="destructive" size="sm" onClick={handleDelete}>
+            Delete
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };


### PR DESCRIPTION
## Summary
- add admin layout to protect admin routes
- create Admin products & orders pages
- add CRUD product form
- add simple Textarea UI component
- document `ADMIN_EMAILS` in example env and README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866af0b6a5c8325accbc30c952f0da9