### PR TITLE
Add product list and cart functionality

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCart } from "@/components/cart-context";
+import { Button } from "@/components/ui/button";
+
+export default function CartPage() {
+  const { items, removeItem, clear } = useCart();
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  const handleCheckout = async () => {
+    // Placeholder: connect to payment service here
+    alert("Redirecting to payment...");
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Your Cart</h1>
+      {items.length === 0 ? (
+        <p>Your cart is empty.</p>
+      ) : (
+        <div className="space-y-4">
+          {items.map((item) => (
+            <div key={item.id} className="flex justify-between border-b pb-2">
+              <div>
+                <p className="font-medium">{item.name}</p>
+                <p className="text-sm text-muted-foreground">
+                  {item.quantity} × ${item.price}
+                </p>
+              </div>
+              <Button variant="ghost" onClick={() => removeItem(item.id)} size="sm">
+                Remove
+              </Button>
+            </div>
+          ))}
+          <p className="font-semibold">Total: ${total.toFixed(2)}</p>
+          <div className="flex gap-2">
+            <Button onClick={handleCheckout}>Checkout</Button>
+            <Button variant="secondary" onClick={clear} type="button">
+              Clear
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist } from "next/font/google";
 import { ThemeProvider } from "next-themes";
+import { CartProvider } from "@/components/cart-context";
 import "./globals.css";
 
 const defaultUrl = process.env.VERCEL_URL
@@ -33,7 +34,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          {children}
+          <CartProvider>{children}</CartProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,0 +1,29 @@
+import { createClient } from "@/lib/supabase/server";
+import { AddToCart } from "@/components/add-to-cart";
+
+export default async function ProductsPage() {
+  const supabase = await createClient();
+  const { data: products } = await supabase
+    .from("products")
+    .select("id,name,description,price");
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Products</h1>
+      <div className="grid gap-4">
+        {products?.length ? (
+          products.map((p) => (
+            <div key={p.id} className="border rounded p-4 space-y-2">
+              <h2 className="font-semibold">{p.name}</h2>
+              {p.description && <p>{p.description}</p>}
+              <p>${p.price}</p>
+              <AddToCart product={{ id: p.id, name: p.name, price: p.price }} />
+            </div>
+          ))
+        ) : (
+          <p>No products found.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/add-to-cart.tsx
+++ b/components/add-to-cart.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useCart, CartItem } from "@/components/cart-context";
+
+export function AddToCart({ product }: { product: Omit<CartItem, "quantity"> }) {
+  const { addItem } = useCart();
+  const handleAdd = () => {
+    addItem({ ...product, quantity: 1 });
+  };
+  return (
+    <Button onClick={handleAdd} size="sm">
+      Add to cart
+    </Button>
+  );
+}

--- a/components/cart-context.tsx
+++ b/components/cart-context.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+export interface CartItem {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+interface CartContextValue {
+  items: CartItem[];
+  addItem: (item: CartItem) => void;
+  removeItem: (id: string) => void;
+  clear: () => void;
+}
+
+const CartContext = createContext<CartContextValue | undefined>(undefined);
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  const addItem = (item: CartItem) =>
+    setItems((prev) => {
+      const existing = prev.find((i) => i.id === item.id);
+      if (existing) {
+        return prev.map((i) =>
+          i.id === item.id ? { ...i, quantity: i.quantity + item.quantity } : i,
+        );
+      }
+      return [...prev, item];
+    });
+
+  const removeItem = (id: string) =>
+    setItems((prev) => prev.filter((i) => i.id !== id));
+
+  const clear = () => setItems([]);
+
+  return (
+    <CartContext.Provider value={{ items, addItem, removeItem, clear }}>
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export function useCart() {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error("useCart must be used within a CartProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add `CartProvider` and `useCart` hook for managing cart state
- show products from Supabase on `/products` with `Add to cart` button
- implement `/cart` page to display items and start checkout
- wrap app with `CartProvider` in `layout.tsx`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866adcb81bc83258e5825c118bee63c