### PR TITLE
Implement fabric reordering with drag-and-drop

### DIFF
--- a/app/admin/fabrics/page.tsx
+++ b/app/admin/fabrics/page.tsx
@@ -1,0 +1,21 @@
+import { createClient } from "@/lib/supabase/server";
+import { FabricList } from "@/components/admin/fabric-list";
+
+export default async function FabricsPage() {
+  const supabase = await createClient();
+  const { data: fabrics, error } = await supabase
+    .from("fabrics")
+    .select("*")
+    .order("sort_order");
+
+  if (error) {
+    console.error(error);
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <h1 className="text-2xl font-bold">Fabrics</h1>
+      {fabrics && <FabricList fabrics={fabrics} />}
+    </div>
+  );
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -37,6 +37,9 @@ export default async function AdminLayout({
               <Link href="/admin/products" className="hover:underline">
                 Products
               </Link>
+              <Link href="/admin/fabrics" className="hover:underline">
+                Fabrics
+              </Link>
               <Link href="/admin/orders" className="hover:underline">
                 Orders
               </Link>

--- a/components/admin/fabric-list.tsx
+++ b/components/admin/fabric-list.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  DndContext,
+  closestCenter,
+  DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
+
+export type Fabric = { id: number; name: string; sort_order: number };
+
+function FabricItem({ fabric }: { fabric: Fabric }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: fabric.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="border rounded p-2 bg-background"
+      {...attributes}
+      {...listeners}
+    >
+      {fabric.name}
+    </li>
+  );
+}
+
+export function FabricList({ fabrics }: { fabrics: Fabric[] }) {
+  const [items, setItems] = useState(fabrics);
+  const router = useRouter();
+  const supabase = createClient();
+
+  const handleDragEnd = async ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    setItems((prev) => {
+      const oldIndex = prev.findIndex((i) => i.id === active.id);
+      const newIndex = prev.findIndex((i) => i.id === over.id);
+      return arrayMove(prev, oldIndex, newIndex);
+    });
+    const newOrder = arrayMove(
+      items,
+      items.findIndex((i) => i.id === active.id),
+      items.findIndex((i) => i.id === over.id),
+    );
+    const updates = newOrder.map((fabric, index) => ({
+      id: fabric.id,
+      sort_order: index,
+    }));
+    const { error } = await supabase.from("fabrics").upsert(updates);
+    if (error) console.error(error);
+    router.refresh();
+  };
+
+  return (
+    <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={items} strategy={verticalListSortingStrategy}>
+        <ul className="flex flex-col gap-2">
+          {items.map((fabric) => (
+            <FabricItem key={fabric.id} fabric={fabric} />
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-checkbox": "^1.3.1",
     "@radix-ui/react-dropdown-menu": "^2.1.14",
     "@radix-ui/react-label": "^2.1.6",


### PR DESCRIPTION
## Summary
- add `@dnd-kit` libraries for drag-and-drop
- expose a `/admin/fabrics` page to edit fabrics
- add `FabricList` client component with drag-and-drop reordering
- include `Fabrics` link in admin navigation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866bde7b5ac8325a33e56e1e997a56f